### PR TITLE
Resolve CEF binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
     message(FATAL_ERROR "CEF-CMake: Download platform not supported yet")
 endif()
 
-set(cefArchiveURL http://opensource.spotify.com/cefbuilds/${cefName}.tar.bz2)
+set(cefArchiveURL https://cef-builds.spotifycdn.com/${cefName}.tar.bz2)
 # fix the url as the version may contain pluses
 string(REGEX REPLACE "\\+" "%2B" cefArchiveURL ${cefArchiveURL})
 set(cefArchive ${CMAKE_CURRENT_SOURCE_DIR}/${cefName}.tar.bz2)


### PR DESCRIPTION
Noticed binaries won't download, found root cause to be the url changed.